### PR TITLE
feat: Task 3 - 商品データモデルの定義

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ProductCreate(BaseModel):
+    """商品作成時のデータモデル"""
+
+    name: str = Field(..., min_length=1, description="商品名")
+    price: float = Field(..., gt=0, description="価格")
+
+
+class Product(ProductCreate):
+    """商品データモデル（レスポンス用）"""
+
+    id: int = Field(..., description="商品ID")
+    created_at: datetime = Field(default_factory=datetime.now, description="作成日時")


### PR DESCRIPTION
## 概要
Task #3 の実装です。
商品のデータ構造をPydanticモデルとして定義しました。

## 関連Issue
Fixes #3

## 実装内容
- [x] `api/models.py`を作成
- [x] `ProductCreate` モデル（リクエスト用）を定義
- [x] `Product` モデル（レスポンス用）を定義
- [x] バリデーションルール（`name`, `price`）を設定