### PR TITLE
feat: Task 5 - 商品作成エンドポイントの実装

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,9 +1,19 @@
 from fastapi import FastAPI
 
+from api.models import Product, ProductCreate
+from api.storage import InMemoryStorage
+
 app = FastAPI(title="商品管理API")
+storage = InMemoryStorage()
 
 
 @app.get("/health")
 async def health_check() -> dict:
     """APIのヘルスチェック"""
     return {"status": "ok"}
+
+
+@app.post("/items", response_model=Product, status_code=201)
+async def create_item(item: ProductCreate) -> Product:
+    """商品を作成する"""
+    return storage.create_product(item)

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -11,3 +11,24 @@ async def test_health_check() -> None:
         response = await client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.anyio
+async def test_create_item_returns_201() -> None:
+    """商品作成エンドポイントが201を返すことをテストする"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/items", json={"name": "テスト商品", "price": 1000})
+    assert response.status_code == 201
+    created_item = response.json()
+    assert created_item["name"] == "テスト商品"
+    assert created_item["price"] == 1000
+    assert "id" in created_item
+    assert "created_at" in created_item
+
+
+@pytest.mark.anyio
+async def test_create_item_with_invalid_price_returns_422() -> None:
+    """不正な価格で商品を作成しようとすると422エラーが返ることをテストする"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/items", json={"name": "テスト商品", "price": 0})
+    assert response.status_code == 422


### PR DESCRIPTION
## 概要
Task #5 の実装です。
TDDサイクルに従い、`POST /items`エンドポイントを実装しました。

## 関連Issue
Fixes #5

## 実装内容
- [x] `POST /items`エンドポイントを追加
- [x] 正常系のテスト（ステータスコード、レスポンス内容）を作成
- [x] 異常系（バリデーションエラー）のテストを作成